### PR TITLE
Configure DNS using terraform

### DIFF
--- a/kops/create-cluster.sh
+++ b/kops/create-cluster.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -ueo pipefail
 
-name="$1"
+env_name="$1"
+cluster_name="${env_name}.k8s.local"
 
-cd "deployments/${name}"
+cd "deployments/${env_name}"
 terraform init
-terraform apply
+terraform apply -var "env=${env_name}"
 
 vpc_id="$(terraform output vpc_id)"
 subnet_ids="$(terraform output subnet_ids)"
@@ -21,7 +22,7 @@ echo "$subnet_ids"
 echo "$azs"
 
 kops create cluster \
-     --name="${name}.k8s.local" \
+     --name="$cluster_name" \
      --state=s3://gds-paas-k8s-shared-state \
      --networking flannel \
      --cloud=aws \

--- a/kops/delete-cluster.sh
+++ b/kops/delete-cluster.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 set -ueo pipefail
 
-name="$1"
+env_name="$1"
+cluster_name="${env_name}.k8s.local"
 
 kops delete cluster \
-     --name="${name}.k8s.local" \
+     --name="${cluster_name}" \
      --state=s3://gds-paas-k8s-shared-state \
      --yes
 
-cd "deployments/${name}"
+cd "deployments/${env_name}"
 terraform init
-terraform destroy
+terraform destroy -var "env=${cluster_name}"
 cd -

--- a/kops/deployments/farmboy/site.tf
+++ b/kops/deployments/farmboy/site.tf
@@ -1,5 +1,15 @@
-variable "env" {
-  default = "farmboy.k8s.local"
+variable "env" {}
+
+variable "root_domain" {
+  default = "govsvc.uk"
+}
+
+locals {
+  domain_name = "${var.env}.${var.root_domain}"
+}
+
+data "aws_route53_zone" "root" {
+  name         = "${var.root_domain}."
 }
 
 variable "region" {
@@ -94,6 +104,20 @@ resource "aws_route_table_association" "rta" {
   route_table_id = "${aws_route_table.rt.id}"
 }
 
+resource "aws_route53_zone" "domain" {
+  name = "${local.domain_name}"
+
+  force_destroy = true
+}
+
+resource "aws_route53_record" "ns" {
+  zone_id = "${data.aws_route53_zone.root.zone_id}"
+  name    = "${local.domain_name}"
+  type    = "NS"
+  ttl     = "60"
+  records = ["${aws_route53_zone.domain.name_servers}"]
+}
+
 output "vpc_id" {
   value = "${aws_vpc.vpc.id}"
 }
@@ -104,4 +128,12 @@ output "subnet_ids" {
 
 output "azs" {
   value = "${join(",", var.azs)}"
+}
+
+output "domain_name" {
+  value = "${aws_route53_zone.domain.name}"
+}
+
+output "domain_zone_id" {
+  value = "${aws_route53_zone.domain.zone_id}"
 }

--- a/kops/deployments/longboy/site.tf
+++ b/kops/deployments/longboy/site.tf
@@ -1,5 +1,15 @@
-variable "env" {
-  default = "longboy.k8s.local"
+variable "env" {}
+
+variable "root_domain" {
+  default = "govsvc.uk"
+}
+
+locals {
+  domain_name = "${var.env}.${var.root_domain}"
+}
+
+data "aws_route53_zone" "root" {
+  name         = "${var.root_domain}."
 }
 
 variable "region" {
@@ -94,6 +104,20 @@ resource "aws_route_table_association" "rta" {
   route_table_id = "${aws_route_table.rt.id}"
 }
 
+resource "aws_route53_zone" "domain" {
+  name = "${local.domain_name}"
+
+  force_destroy = true
+}
+
+resource "aws_route53_record" "ns" {
+  zone_id = "${data.aws_route53_zone.root.zone_id}"
+  name    = "${local.domain_name}"
+  type    = "NS"
+  ttl     = "60"
+  records = ["${aws_route53_zone.domain.name_servers}"]
+}
+
 output "vpc_id" {
   value = "${aws_vpc.vpc.id}"
 }
@@ -104,4 +128,12 @@ output "subnet_ids" {
 
 output "azs" {
   value = "${join(",", var.azs)}"
+}
+
+output "domain_name" {
+  value = "${aws_route53_zone.domain.name}"
+}
+
+output "domain_zone_id" {
+  value = "${aws_route53_zone.domain.zone_id}"
 }

--- a/kops/deployments/mediumboy/site.tf
+++ b/kops/deployments/mediumboy/site.tf
@@ -1,5 +1,15 @@
-variable "env" {
-  default = "mediumboy.k8s.local"
+variable "env" {}
+
+variable "root_domain" {
+  default = "govsvc.uk"
+}
+
+locals {
+  domain_name = "${var.env}.${var.root_domain}"
+}
+
+data "aws_route53_zone" "root" {
+  name         = "${var.root_domain}."
 }
 
 variable "region" {
@@ -94,6 +104,20 @@ resource "aws_route_table_association" "rta" {
   route_table_id = "${aws_route_table.rt.id}"
 }
 
+resource "aws_route53_zone" "domain" {
+  name = "${local.domain_name}"
+
+  force_destroy = true
+}
+
+resource "aws_route53_record" "ns" {
+  zone_id = "${data.aws_route53_zone.root.zone_id}"
+  name    = "${local.domain_name}"
+  type    = "NS"
+  ttl     = "60"
+  records = ["${aws_route53_zone.domain.name_servers}"]
+}
+
 output "vpc_id" {
   value = "${aws_vpc.vpc.id}"
 }
@@ -104,4 +128,12 @@ output "subnet_ids" {
 
 output "azs" {
   value = "${join(",", var.azs)}"
+}
+
+output "domain_name" {
+  value = "${aws_route53_zone.domain.name}"
+}
+
+output "domain_zone_id" {
+  value = "${aws_route53_zone.domain.zone_id}"
 }


### PR DESCRIPTION
~~Kops has a domain name of which it is aware. Now that we have a domain
that we can use we can use this. This should simplify our service
configuration when using ingress, etc.~~

~~Additionally we were managing the state of the DNS records using
scripting, when we can use terraform instead.~~



    Instead of doing route53 stuff using a script, we can do it using
    terraform when we create the cluster, we can then use terraform to pull
    out the IDs

    The side effect of this is we are reducing the number of IAM permissions
    required to converge a cluster. This means that we can have separate
    access levels for creating and converging a cluster, as the cluster
    manages its own IAM.